### PR TITLE
User require --dev vs regular require

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 Add the FakerMarkdownGenerator library to your `composer.json` file:
 
 ```
-composer require davidbadura/faker-markdown-generator
+composer require --dev davidbadura/faker-markdown-generator
 ```
 
 Usage


### PR DESCRIPTION
Since I see no reason for anyone to use fake in production I'd suggest requiring it as a dev dependency.